### PR TITLE
add IPC system for getting train list

### DIFF
--- a/HuntHelper/Managers/IpcSystem.cs
+++ b/HuntHelper/Managers/IpcSystem.cs
@@ -1,0 +1,68 @@
+﻿using Dalamud.Plugin;
+using Dalamud.Plugin.Ipc;
+using Dalamud.Plugin.Services;
+using HuntHelper.Managers.Hunts;
+using HuntHelper.Managers.Hunts.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Threading.Tasks;
+
+namespace HuntHelper.Managers;
+
+public class IpcSystem : IDisposable
+{
+    private const uint HuntHelperApiVersion = 1;
+    
+    private readonly DalamudPluginInterface _pluginInterface;
+    private readonly IFramework _framework;
+    private readonly TrainManager _trainManager;
+    
+    private readonly ICallGateProvider<uint> _cgGetVersion;
+    private readonly ICallGateProvider<List<MobRecord>> _cgGetTrainList;
+
+    public IpcSystem(DalamudPluginInterface pluginInterface, IFramework framework, TrainManager trainManager)
+    {
+        _pluginInterface = pluginInterface;
+        _framework = framework;
+        _trainManager = trainManager;
+        
+        _cgGetVersion = pluginInterface.GetIpcProvider<uint>("HH.GetVersion");
+        _cgGetTrainList = pluginInterface.GetIpcProvider<List<MobRecord>>("HH.GetTrainList");
+        
+        _cgGetVersion.RegisterFunc(GetVersion);
+        _cgGetTrainList.RegisterFunc(GetTrainList);
+
+        pluginInterface.GetIpcProvider<uint, bool>("HH.Enable").SendMessage(HuntHelperApiVersion);
+    }
+
+    public void Dispose()
+    {
+        _cgGetVersion.UnregisterFunc();
+        _cgGetTrainList.UnregisterFunc();
+
+        _pluginInterface.GetIpcProvider<bool>("HH.Disable");
+    }
+
+    private static uint GetVersion() => HuntHelperApiVersion;
+
+    private List<MobRecord> GetTrainList() =>
+        _framework.RunOnFrameworkThread(() =>
+            _trainManager.HuntTrain.Select(AsMobRecord).ToList()
+        ).Result;
+
+    private static MobRecord AsMobRecord(HuntTrainMob mob) =>
+        new MobRecord(mob.Name, mob.MobID, mob.TerritoryID, mob.MapID, mob.Instance, mob.Position, mob.Dead, mob.LastSeenUTC);
+
+    private record struct MobRecord(
+        string Name,
+        uint MobID,
+        uint TerritoryID,
+        uint MapID,
+        uint Instance,
+        Vector2 Position,
+        bool Dead,
+        DateTime LastSeenUTC
+    );
+}

--- a/HuntHelper/Plugin.cs
+++ b/HuntHelper/Plugin.cs
@@ -1,23 +1,15 @@
-﻿using Dalamud.Data;
-using Dalamud.Game.ClientState;
-using Dalamud.Game.ClientState.Objects;
-using Dalamud.Game.Command;
-using Dalamud.Game.Gui;
-using Dalamud.Game.Gui.FlyText;
+﻿using Dalamud.Game.Command;
 using Dalamud.Logging;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Ipc;
+using Dalamud.Plugin.Services;
 using HuntHelper.Gui;
+using HuntHelper.Gui.Resource;
+using HuntHelper.Managers;
 using HuntHelper.Managers.Hunts;
 using HuntHelper.Managers.MapData;
-using Newtonsoft.Json;
-using System.Collections.Generic;
 using System;
 using System.IO;
-using Dalamud;
-using Dalamud.Game.ClientState.Fates;
-using Dalamud.Plugin.Services;
-using HuntHelper.Gui.Resource;
 
 namespace HuntHelper
 {
@@ -51,6 +43,7 @@ namespace HuntHelper
         private HuntManager HuntManager { get; init; }
         private TrainManager TrainManager { get; init; }
         private MapDataManager MapDataManager { get; init; }
+        private IpcSystem IpcSystem { get; init; }
         private IFlyTextGui FlyTextGui { get; init; }
         private IGameGui GameGui { get; init; }
 
@@ -61,6 +54,7 @@ namespace HuntHelper
 
         public Plugin(
             DalamudPluginInterface pluginInterface,
+            IFramework framework,
             ICommandManager commandManager,
             IClientState clientState,
             IObjectTable objectTable,
@@ -97,6 +91,7 @@ namespace HuntHelper
             this.TrainManager = new TrainManager(ChatGui, GameGui, dataManager, Path.Combine(PluginInterface.AssemblyLocation.Directory?.FullName!, @"Data\HuntTrain.json"));
             this.HuntManager = new HuntManager(PluginInterface, TrainManager, chatGui, flyTextGui, this.Configuration.TTSVolume);
             this.MapDataManager = new MapDataManager(Path.Combine(PluginInterface.AssemblyLocation.Directory?.FullName!, @"Data\SpawnPointData.json"));
+            this.IpcSystem = new IpcSystem(pluginInterface, framework, TrainManager);
 
             this.MapUi = new MapUI(this.Configuration, pluginInterface, clientState, objectTable, dataManager, HuntManager, MapDataManager, GameGui);
             this.HuntTrainUI = new HuntTrainUI(TrainManager, Configuration);
@@ -160,6 +155,7 @@ namespace HuntHelper
             this.CounterUI.SaveSettings();
             this.SpawnPointFinderUI.SaveSettings();
 
+            this.IpcSystem.Dispose();
             //this.HuntTrainUI.Dispose();
             this.SpawnPointFinderUI.Dispose();
             this.CounterUI.Dispose();


### PR DESCRIPTION
in order to support companion plugins, this PR adds an IPC system to allow other plugins to pull the train list from Hunt Helper.

i thought it would be good to update the readme or somewhere, to describe the IPC functions available, but i wasn't sure where would be the appropriate place. Let me know where and i'll add some documentation about the available functions!

i've added 4 IPC functions, following a pattern that other dalamud contributors recommended:
* `HH.GetTrainList` - returns the mob list from the train recorder.
* `HH.GetVersion` - returns a version number for the Hunt Helper IPC system. This allows other plugins to check the version of Hunt Helper's IPC functions, so they can avoid errors by not even calling the other IPC functions if the version isn't what they expect. This version only needs to updated with breaking changes.
* `HH.Enable` - this is a pub/sub signal that other plugins can subscribe to in order to know when Hunt Helper is enabled, ensuring other plugins don't waste time repeatedly calling IPC functions when Hunt Helper isn't around.
* `HH.Disable` - another pub/sub signal that other plugins can subscribe to, this time to know when Hunt Helper is being disabled. This allows other plugins to gracefully disable their Hunt Helper integration when Hunt Helper is turned off.