### PR TITLE
publish an ipc message when a mob is seen

### DIFF
--- a/HuntHelper/Gui/MapUI.cs
+++ b/HuntHelper/Gui/MapUI.cs
@@ -1411,7 +1411,7 @@ namespace HuntHelper.Gui
             _huntManager.AddNearbyMobs(nearbyMobs, _mapZoneMaxCoordSize, _territoryId, MapHelpers.GetMapID(_territoryId),
                 _ttsAEnabled, _ttsBEnabled, _ttsSEnabled, _ttsAMessage, _ttsBMessage, _ttsSMessage,
                 _chatAEnabled, _chatBEnabled, _chatSEnabled, _chatAMessage, _chatBMessage, _chatSMessage,
-                _flyTxtAEnabled, _flyTxtBEnabled, _flyTxtSEnabled, _instance);
+                _flyTxtAEnabled, _flyTxtBEnabled, _flyTxtSEnabled, _instance, _territoryName);
             UpdateStats();
 
 

--- a/HuntHelper/Gui/MapUI.cs
+++ b/HuntHelper/Gui/MapUI.cs
@@ -1411,7 +1411,7 @@ namespace HuntHelper.Gui
             _huntManager.AddNearbyMobs(nearbyMobs, _mapZoneMaxCoordSize, _territoryId, MapHelpers.GetMapID(_territoryId),
                 _ttsAEnabled, _ttsBEnabled, _ttsSEnabled, _ttsAMessage, _ttsBMessage, _ttsSMessage,
                 _chatAEnabled, _chatBEnabled, _chatSEnabled, _chatAMessage, _chatBMessage, _chatSMessage,
-                _flyTxtAEnabled, _flyTxtBEnabled, _flyTxtSEnabled, _instance, _territoryName);
+                _flyTxtAEnabled, _flyTxtBEnabled, _flyTxtSEnabled, _instance);
             UpdateStats();
 
 

--- a/HuntHelper/Managers/Hunts/HuntManager.cs
+++ b/HuntHelper/Managers/Hunts/HuntManager.cs
@@ -163,7 +163,7 @@ public class HuntManager : IDisposable
     public void AddNearbyMobs(List<IBattleNpc> nearbyMobs, float zoneMapCoordSize, uint territoryId, uint mapid,
         bool aTTS, bool bTTS, bool sTTS, string aTTSmsg, string bTTSmsg, string sTTSmsg,
         bool chatA, bool chatB, bool chatS, string chatAmsg, string chatBmsg, string chatSmsg,
-        bool flyTxtA, bool flyTxtB, bool flyTxtS, uint instance, string territoryName)
+        bool flyTxtA, bool flyTxtB, bool flyTxtS, uint instance)
     {
         //compare with old list
         //move old mob set out
@@ -181,7 +181,7 @@ public class HuntManager : IDisposable
             //if exists in old mob set, skip tts + chat
             if (_previousMobs.Any(hunt => hunt.Mob.NameId == mob.NameId)) continue;
             
-            MarkSeen?.Invoke(mob.ToHuntTrainMob(territoryId, mapid, instance, territoryName, zoneMapCoordSize));
+            MarkSeen?.Invoke(mob.ToHuntTrainMob(territoryId, mapid, instance, MapHelpers.GetMapName(territoryId), zoneMapCoordSize));
 
             //Do tts and chat stuff
             var rank = GetHuntRank(mob.NameId);

--- a/HuntHelper/Managers/Hunts/HuntManager.cs
+++ b/HuntHelper/Managers/Hunts/HuntManager.cs
@@ -72,6 +72,9 @@ public class HuntManager : IDisposable
     public List<HuntTrainMob> ImportedTrain { get; init; }
 
     public List<(HuntRank Rank, IBattleNpc Mob)> CurrentMobs => _currentMobs;
+    
+    public event Action<HuntTrainMob> MarkSeen;
+    
 
     public HuntManager(IDalamudPluginInterface pluginInterface, TrainManager trainManager, IChatGui chatGui, IFlyTextGui flyTextGui, int ttsVolume)
     {
@@ -160,7 +163,7 @@ public class HuntManager : IDisposable
     public void AddNearbyMobs(List<IBattleNpc> nearbyMobs, float zoneMapCoordSize, uint territoryId, uint mapid,
         bool aTTS, bool bTTS, bool sTTS, string aTTSmsg, string bTTSmsg, string sTTSmsg,
         bool chatA, bool chatB, bool chatS, string chatAmsg, string chatBmsg, string chatSmsg,
-        bool flyTxtA, bool flyTxtB, bool flyTxtS, uint instance)
+        bool flyTxtA, bool flyTxtB, bool flyTxtS, uint instance, string territoryName)
     {
         //compare with old list
         //move old mob set out
@@ -177,6 +180,8 @@ public class HuntManager : IDisposable
 
             //if exists in old mob set, skip tts + chat
             if (_previousMobs.Any(hunt => hunt.Mob.NameId == mob.NameId)) continue;
+            
+            MarkSeen?.Invoke(mob.ToHuntTrainMob(territoryId, mapid, instance, territoryName, zoneMapCoordSize));
 
             //Do tts and chat stuff
             var rank = GetHuntRank(mob.NameId);

--- a/HuntHelper/Managers/Hunts/Models/HuntTrainMob.cs
+++ b/HuntHelper/Managers/Hunts/Models/HuntTrainMob.cs
@@ -2,6 +2,8 @@
 using Newtonsoft.Json;
 using System;
 using System.Numerics;
+using Dalamud.Game.ClientState.Objects.Types;
+using HuntHelper.Utilities;
 
 namespace HuntHelper.Managers.Hunts.Models;
 
@@ -59,4 +61,28 @@ public class HuntTrainMob
     {
         return MobID == mobID && Instance == instance;
     }
+}
+
+public static class HuntTrainMobExtensions
+{
+    public static HuntTrainMob ToHuntTrainMob(
+        this IBattleNpc mob,
+        uint territoryId,
+        uint mapId,
+        uint instance,
+        string mapName,
+        float zoneMapCoordSize,
+        bool isDead = false
+    ) =>
+        new(
+            mob.Name.TextValue,
+            mob.NameId,
+            territoryId,
+            mapId,
+            instance,
+            mapName,
+            MapHelpers.ConvertToMapCoordinate(mob.Position, zoneMapCoordSize),
+            DateTime.UtcNow,
+            isDead
+        );
 }

--- a/HuntHelper/Plugin.cs
+++ b/HuntHelper/Plugin.cs
@@ -97,7 +97,7 @@ namespace HuntHelper
             DebugUI = new DebugUI(aeth, dataManager, clientState, HuntManager, objectTable);
 #endif
 
-            IpcSystem = new IpcSystem(pluginInterface, framework, TrainManager);
+            IpcSystem = new IpcSystem(pluginInterface, framework, TrainManager, HuntManager);
             TeleportIpc = pluginInterface.GetIpcSubscriber<uint, byte, bool>("Teleport");
 
             CommandManager.AddHandler(MapWindowCommand, new CommandInfo(HuntMapCommand) { HelpMessage = GuiResources.PluginText["/hh helpmessage"] });

--- a/HuntHelper/Utilities/MapHelpers.cs
+++ b/HuntHelper/Utilities/MapHelpers.cs
@@ -6,6 +6,7 @@ using Lumina.Excel.GeneratedSheets;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Numerics;
 using System.Threading.Tasks;
 
 namespace HuntHelper.Utilities;
@@ -62,6 +63,14 @@ public class MapHelpers
     public static float ConvertToMapCoordinate(float pos, float zoneMaxCoordSize)
     {
         return (float)Math.Floor(((zoneMaxCoordSize + 1.96) / 2 + (pos / 50)) * 100) / 100;
+    }
+
+    public static Vector2 ConvertToMapCoordinate(Vector3 pos, float zoneMaxCoordSize)
+    {
+        return new Vector2(
+            ConvertToMapCoordinate(pos.X, zoneMaxCoordSize),
+            ConvertToMapCoordinate(pos.Z, zoneMaxCoordSize)
+        );
     }
 
     public static void LocaliseMobNames(List<HuntTrainMob> trainList)


### PR DESCRIPTION
not sure if this will be the final implementation of this, but i wanted to get a PR made in order to start discussing the idea.

it would be nice to essentially be alerted whenever a mark is seen. scout helper would like to use that to automatically update tracker links as scouters do their scouting. so this change introduces a publish channel in the hunt helper ipc system that sends a message every time a mob is seen. scout helper can then subscribe to that in order to receive updates.

i will want to test this thoroughly with scout helper before merging this PR, but wanted to get your feedback on the idea while i implement it in scout helper.