### PR TITLE
update map coord math

### DIFF
--- a/HuntHelper/Gui/MapUI.cs
+++ b/HuntHelper/Gui/MapUI.cs
@@ -146,7 +146,7 @@ namespace HuntHelper.Gui
         #endregion
 
         private bool _showDebug = false;
-        private float _mapZoneMaxCoordSize = 41; //default to 41 as thats most common for hunt zones
+        private float _mapZoneMaxCoordSize = 100; //default to 100 as thats most common for hunt zones
 
         public float SingleCoordSize => ImGui.GetWindowSize().X / _mapZoneMaxCoordSize;
         //message input lengths

--- a/HuntHelper/Managers/Hunts/HuntManager.cs
+++ b/HuntHelper/Managers/Hunts/HuntManager.cs
@@ -414,9 +414,9 @@ public class HuntManager : IDisposable
 
     public float GetMapZoneCoordSize(ushort mapID)
     {
-        //EVERYTHING EXCEPT HEAVENSWARD HAS 41 COORDS, BUT FOR SOME REASON HW HAS 43, WHYYYYYY
-        if (mapID is >= 397 and <= 402) return 43.1f;
-        return 41f;
+        //EVERYTHING EXCEPT HEAVENSWARD HAS A SCALE OF 100, BUT FOR SOME REASON HW HAS 95, WHYYYYYY
+        if (mapID is >= 397 and <= 402) return 95f;
+        return 100f;
     }
     //override tostring?
     public string GetDatabaseAsString()

--- a/HuntHelper/Utilities/MapHelpers.cs
+++ b/HuntHelper/Utilities/MapHelpers.cs
@@ -62,7 +62,7 @@ public class MapHelpers
 
     public static float ConvertToMapCoordinate(float pos, float zoneMaxCoordSize)
     {
-        return (float)Math.Floor(((zoneMaxCoordSize + 1.96) / 2 + (pos / 50)) * 100) / 100;
+        return 2048f / zoneMaxCoordSize + pos / 50f + 1f;
     }
 
     public static Vector2 ConvertToMapCoordinate(Vector3 pos, float zoneMaxCoordSize)


### PR DESCRIPTION
the math used here worked for non-hw maps, but was noticeably off for hw maps. dalamud has logic to convert from raw to map coords that seems to be based on a game binary reference (https://github.com/goatcorp/Dalamud/blob/0fb7585973ffe22ab9353d853b0084a3f1c0803b/Dalamud/Utility/MapUtil.cs#L28). after some testing, we've confirmed that the dalamud calculation is accurate for all maps, including hw. so this change introduces the logic used by dalamud, to fix coords for hw maps, but especially the flags generated by hh for hw.
